### PR TITLE
Fix Cloudflare Terraform issues

### DIFF
--- a/infra/cloudflare.tf
+++ b/infra/cloudflare.tf
@@ -2,7 +2,7 @@
 resource "cloudflare_record" "cdn" {
   zone_id = var.cloudflare_zone_id
   name    = var.cdn_subdomain
-  value   = "storage.googleapis.com"
+  content = "storage.googleapis.com"
   type    = "CNAME"
   proxied = true
 }
@@ -41,7 +41,7 @@ resource "cloudflare_ruleset" "origin_override" {
   rules {
     action = "route"
     action_parameters {
-      host_header_override = "storage.googleapis.com"
+      host_header = "storage.googleapis.com"
     }
     expression  = "http.host eq \"${var.cdn_subdomain}.${var.domain_name}\""
     description = "Override host header to storage.googleapis.com"
@@ -55,7 +55,7 @@ resource "cloudflare_ruleset" "cache_settings" {
   name        = "CDN Caching Rules"
   description = "Cache everything for the photo CDN"
   kind        = "zone"
-  phase       = "http_cache_settings"
+  phase       = "http_request_cache_settings"
 
   rules {
     action = "set_cache_settings"


### PR DESCRIPTION
## Summary
This Pull Request resolves several issues identified in the Cloudflare Terraform configuration:
- **Deprecated Argument:** Updated `cloudflare_record.cdn` to use the `content` attribute instead of the deprecated `value` attribute.
- **Invalid Ruleset Phase:** In `cloudflare_ruleset.cache_settings`, changed the `phase` from `http_cache_settings` to `http_request_cache_settings`, which is the correct phase for cache rules.
- **Unsupported Argument:** In `cloudflare_ruleset.origin_override`, changed the `host_header_override` attribute to `host_header`. The `route` action in the `http_request_origin` phase uses `host_header` to rewrite the Host header sent to the origin (GCS).

These changes ensure the Terraform plan passes and follows the Cloudflare provider v4 conventions.