### PR TITLE
Rename GCS bucket to domain and remove failing rulesets

### DIFF
--- a/infra/cloudflare.tf
+++ b/infra/cloudflare.tf
@@ -7,48 +7,6 @@ resource "cloudflare_record" "cdn" {
   proxied = true
 }
 
-# Transform Rule: Rewrite URI to prepend bucket name
-resource "cloudflare_ruleset" "path_rewrite" {
-  zone_id     = var.cloudflare_zone_id
-  name        = "Rewrite GCS Path"
-  description = "Prepend bucket name to GCS requests"
-  kind        = "zone"
-  phase       = "http_request_transform"
-
-  rules {
-    action = "rewrite"
-    action_parameters {
-      uri {
-        path {
-          expression = "concat(\"/${google_storage_bucket.photos_bucket.name}\", http.request.uri.path)"
-        }
-      }
-    }
-    expression  = "http.host eq \"${var.cdn_subdomain}.${var.domain_name}\""
-    description = "Prepend /${google_storage_bucket.photos_bucket.name} to path"
-    enabled     = true
-  }
-}
-
-# Origin Rule: Override Host header to storage.googleapis.com
-resource "cloudflare_ruleset" "origin_override" {
-  zone_id     = var.cloudflare_zone_id
-  name        = "GCS Origin Host Override"
-  description = "Override host header for GCS"
-  kind        = "zone"
-  phase       = "http_request_origin"
-
-  rules {
-    action = "route"
-    action_parameters {
-      host_header = "storage.googleapis.com"
-    }
-    expression  = "http.host eq \"${var.cdn_subdomain}.${var.domain_name}\""
-    description = "Override host header to storage.googleapis.com"
-    enabled     = true
-  }
-}
-
 # Cache Rule: Cache Everything
 resource "cloudflare_ruleset" "cache_settings" {
   zone_id     = var.cloudflare_zone_id

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -62,12 +62,8 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
 }
 
 # New public storage bucket for photos
-resource "random_id" "bucket_suffix" {
-  byte_length = 4
-}
-
 resource "google_storage_bucket" "photos_bucket" {
-  name                        = "${var.photos_bucket_name}-${random_id.bucket_suffix.hex}"
+  name                        = "${var.cdn_subdomain}.${var.domain_name}"
   location                    = "europe-west4"
   uniform_bucket_level_access = true
 


### PR DESCRIPTION
## Summary
This PR resolves the Cloudflare entitlement error "not entitled to use the HostHeader override" by renaming the GCS photo bucket to exactly match the domain name (`cdn.rikribbers.nl`).

### Changes
- **Bucket Renaming:** Renamed `google_storage_bucket.photos_bucket` to `cdn.rikribbers.nl`. GCS uses the `Host` header to identify buckets for custom domains. By matching the bucket name to the domain, we no longer need to override the Host header.
- **Removed Rulesets:** Deleted `cloudflare_ruleset.origin_override` and `cloudflare_ruleset.path_rewrite`. These are no longer required because GCS will naturally serve the content when the Host header matches the bucket name.
- **Clean URLs & Zero Cost:** This maintains clean URLs and preserves the Bandwidth Alliance benefits (free egress).

### Important: DNS Verification Required
Before this PR can be applied, you must verify domain ownership for `rikribbers.nl` in the Google Search Console:
1. Go to [Google Search Console](https://search.console.google.com/search-console).
2. Add the domain `rikribbers.nl`.
3. Follow the DNS verification steps (adding a TXT record in Cloudflare).
4. Once verified, Terraform will be able to create the domain-named bucket.

**Note:** Renaming the bucket will cause Terraform to delete the old bucket and create a new one. Ensure any existing data is backed up if needed.